### PR TITLE
Fix gitleaks.yml yamllint issues

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,6 +1,6 @@
 name: Gitleaks Secret Detection
 
-on:
+"on":
   pull_request:
   push:
     branches:
@@ -16,23 +16,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0  # Fetch all history for all branches and tags
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
       - name: Upload Gitleaks report as artifact
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: gitleaks-report
           path: |
             **/gitleaks-report.json
             **/gitleaks-report.sarif
           retention-days: 30
-


### PR DESCRIPTION
## Summary

This PR fixes yamllint linting errors in the Gitleaks workflow file.

## Changes

✅ Changed `on:` to `"on":` (yamllint truthy compliance)
✅ Added 2 spaces before inline comments
✅ Removed extra blank lines at end of file

## Errors Fixed

```
[warning] truthy value should be one of [false, true]
[warning] too few spaces before comment: expected 2
[error] too many blank lines (1 > 0)
```

## Validation

✅ Tested on: https://github.com/takemobiteam/planner-aa-lambdas/pull/379
✅ All yamllint checks passing
✅ Workflow functionality unchanged

---

🤖 Automated org-wide deployment